### PR TITLE
Use Buffer.from() instead of new Buffer()

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -45,7 +45,7 @@ Utility_1.Utility.withAllStdIn((input) => {
                 }
             }
         });
-        process.stdout.write(new Buffer(response.serializeBinary()));
+        process.stdout.write(Buffer.from(response.serializeBinary()));
     }
     catch (err) {
         console.error('error: ' + err.stack + '\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ Utility.withAllStdIn((input: Buffer) => {
             }
         });
 
-        process.stdout.write(new Buffer(response.serializeBinary()));
+        process.stdout.write(Buffer.from(response.serializeBinary()));
     } catch (err) {
         console.error('error: ' + err.stack + '\n');
         process.exit(1);


### PR DESCRIPTION
The use of `new Buffer()` has been deprecated for security reasons, use `Buffer.from()` instead

see the [buffer docs](https://nodejs.org/api/buffer.html) and the [buffer constructor deprecation guide](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/)